### PR TITLE
Fixing CreatureSpawnEvent error

### DIFF
--- a/src/main/java/com/hotmail/wolfiemario/rebalancevillagers/RebalanceVillagers.java
+++ b/src/main/java/com/hotmail/wolfiemario/rebalancevillagers/RebalanceVillagers.java
@@ -141,13 +141,13 @@ public class RebalanceVillagers extends JavaPlugin implements Listener {
         Entity entity = event.getEntity();
         EntityType entityType = event.getEntityType();
 
-        net.minecraft.server.v1_6_R3.World mcWorld = ((CraftWorld) entity
+        final net.minecraft.server.v1_6_R3.World mcWorld = ((CraftWorld) entity
                 .getWorld()).getHandle();
         net.minecraft.server.v1_6_R3.Entity mcEntity = (((CraftEntity) entity)
                 .getHandle());
 
         if (entityType == EntityType.VILLAGER) {
-            EntityVillager entityVil = (EntityVillager) mcEntity;
+            final EntityVillager entityVil = (EntityVillager) mcEntity;
 
             // This should only occur if convertVillager triggered this event.
             // This is unnecessary repetition; skip it.
@@ -175,7 +175,12 @@ public class RebalanceVillagers extends JavaPlugin implements Listener {
                 if (ShopkeepersHelper.shopkeepersActive()) {
                     Bukkit.getScheduler().runTaskAsynchronously(this, new ShopkeeperWaiter(entityVil, mcWorld, this));
                 } else {
-                    convertVillager(entityVil, mcWorld);
+                	Bukkit.getScheduler().runTask(this, new Runnable() {
+						@Override
+						public void run() {
+		                    convertVillager(entityVil, mcWorld);
+						}
+                	});
                 }
 
             }


### PR DESCRIPTION
Developer comment (@matejdro): 

> Error is about Rebelance Villagers scanning for possible mate and while it is still scanning it also tries to delete one villager which of course does not work.

This fixed the issue, villagers are mating properly, no errors show up.
